### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It depends on the ability to access a local web-api in Zotero 7.
 This was inspired by a repository using Node.js and the web api: [mcp-zotero](https://github.com/kaliaboi/mcp-zotero).  
 This builds on the shoulders of the fantastic [pyzotero](https://github.com/urschrei/pyzotero) library.
 
+<a href="https://glama.ai/mcp/servers/q5adqkd02d"><img width="380" height="200" src="https://glama.ai/mcp/servers/q5adqkd02d/badge" alt="Zotero Connector MCP server" /></a>
+
 ## Installation
 
 Information about Claude Desktop interacting with MCPs can be found [here](https://modelcontextprotocol.io/quickstart/user).


### PR DESCRIPTION
This PR adds a badge for the [Zotero MCP Connector](https://glama.ai/mcp/servers/q5adqkd02d) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/q5adqkd02d"><img width="380" height="200" src="https://glama.ai/mcp/servers/q5adqkd02d/badge" alt="Zotero Connector MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.